### PR TITLE
rules/sdk: detect overflowing bitsize in strconv.ParseUint in cast to int*

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1ls
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -63,6 +64,7 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -97,6 +99,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -114,11 +117,13 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -107,6 +107,7 @@ func Generate(filters ...RuleFilter) RuleList {
 		{"G701", "Casting integers", sdk.NewIntegerCast},
 		{"G702", "Import blocklist for SDK modules", sdk.NewUnsafeImport},
 		{"G703", "Errors that don't result in rollback", sdk.NewErrorNotPropagated},
+		{"G704", "Strconv invalid bitSize and cast", sdk.NewStrconvIntBitSizeOverflow},
 	}
 
 	ruleMap := make(map[string]RuleDefinition)

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -87,6 +87,10 @@ var _ = Describe("gosec rules", func() {
 			runner("G109", testutils.SampleCodeG109)
 		})
 
+		It("should detect strconv bitsize mismatch", func() {
+			runner("G704", testutils.SampleCodeStrconvBitsize)
+		})
+
 		It("should detect DoS vulnerability via decompression bomb", func() {
 			runner("G110", testutils.SampleCodeG110)
 		})

--- a/rules/sdk/strconv_bitsize_mismatch.go
+++ b/rules/sdk/strconv_bitsize_mismatch.go
@@ -1,0 +1,156 @@
+// (c) Copyright 2021 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"fmt"
+	"go/ast"
+	"strconv"
+
+	"github.com/securego/gosec/v2"
+)
+
+type bitsizeOverflowCheck struct {
+	gosec.MetaData
+	calls gosec.CallList
+}
+
+func (bc *bitsizeOverflowCheck) ID() string {
+	return bc.MetaData.ID
+}
+
+func (bc *bitsizeOverflowCheck) Match(node ast.Node, ctx *gosec.Context) (*gosec.Issue, error) {
+	var parseUintVarObj map[*ast.Object]ast.Node
+
+	// Given that the code could be splayed over multiple line, we
+	// examine ctx.PassedValues to check for temporarily stored data.
+	if retr, ok := ctx.PassedValues[bc.ID()]; !ok {
+		parseUintVarObj = make(map[*ast.Object]ast.Node)
+		ctx.PassedValues[bc.ID()] = parseUintVarObj
+	} else if saved, ok := retr.(map[*ast.Object]ast.Node); ok {
+		parseUintVarObj = saved
+	} else {
+		return nil, fmt.Errorf("ctx.PassedValues[%s] is of type %T, want %T", bc.ID(), retr, parseUintVarObj)
+	}
+
+	// strconv.ParseUint*
+	// To reduce false positives, detect code that is converted to any of: int16, int32, int64 only.
+	switch n := node.(type) {
+	case *ast.AssignStmt:
+		for _, expr := range n.Rhs {
+			callExpr, ok := expr.(*ast.CallExpr)
+			if !ok {
+				continue
+			}
+
+			if bc.calls.ContainsPkgCallExpr(callExpr, ctx, false) == nil {
+				continue
+			}
+
+			ident, ok := n.Lhs[0].(*ast.Ident)
+			if ok && ident.Name != "_" {
+				parseUintVarObj[ident.Obj] = n
+			}
+		}
+
+	case *ast.CallExpr:
+		fn, ok := n.Fun.(*ast.Ident)
+		if !ok {
+			return nil, nil
+		}
+
+		switch fn.Name {
+		default:
+			return nil, nil
+
+		case "int", "int16", "int32", "int64":
+			ident, ok := n.Args[0].(*ast.Ident)
+			if !ok {
+				return nil, nil
+			}
+
+			nFound, ok := parseUintVarObj[ident.Obj]
+			if !ok {
+				return nil, nil
+			}
+
+			stmt, ok := nFound.(*ast.AssignStmt)
+			if !ok {
+				return nil, nil
+			}
+			r0 := stmt.Rhs[0]
+			call, ok := r0.(*ast.CallExpr)
+			if !ok {
+				return nil, nil
+			}
+			bitSizeLit, ok := call.Args[2].(*ast.BasicLit)
+			if !ok {
+				return nil, nil
+			}
+
+			// Actually strconv parse it.
+			bitSize, err := strconv.Atoi(bitSizeLit.Value)
+			if err != nil {
+				failure := fmt.Sprintf("Invalid bitSize %q parse failure: %v", bitSizeLit.Value, err)
+				return gosec.NewIssue(ctx, nFound, bc.ID(), failure, bc.Severity, bc.Confidence), nil
+			}
+
+			failed := false
+			switch {
+			case fn.Name == "int16" && bitSize >= 16:
+				failed = true
+			case fn.Name == "int64" && bitSize >= 64:
+				failed = true
+			case fn.Name == "int32" && bitSize >= 32:
+				failed = true
+			case fn.Name == "int" && (bitSize == 32 || bitSize >= 64):
+				failed = true
+			}
+
+			if !failed {
+				return nil, nil
+			}
+
+			// Otherwise compose the message now.
+			failure := fmt.Sprintf("Overflow in bitSize of %d for %q", bitSize, fn.Name)
+
+			// The value was found, next let's check for the size of:
+			// strconv.ParseUint(str, base, digits)
+			// Awesome, we found the conversion to int*
+			// Next we need to examine what the bitSize was.
+			return gosec.NewIssue(ctx, nFound, bc.ID(), failure, bc.Severity, bc.Confidence), nil
+		}
+	}
+
+	return nil, nil
+}
+
+func NewStrconvIntBitSizeOverflow(id string, config gosec.Config) (rule gosec.Rule, nodes []ast.Node) {
+	calls := gosec.NewCallList()
+	calls.Add("strconv", "ParseUint")
+
+	bc := &bitsizeOverflowCheck{
+		MetaData: gosec.MetaData{
+			ID:         id,
+			Severity:   gosec.High,
+			Confidence: gosec.Medium,
+			What:       "Overflow due to wrong bitsize in strconv.ParseUint yet cast from uint64 to int*",
+		},
+		calls: calls,
+	}
+
+	nodes = append(nodes, (*ast.FuncDecl)(nil), (*ast.AssignStmt)(nil), (*ast.CallExpr)(nil))
+	return bc, nodes
+}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2313,4 +2313,90 @@ func main() {
         C.printData(cData)
 }
 `}, 0, gosec.NewConfig()}}
+
+	// SampleCodeStrconvBitsize - Potential Integer OverFlow
+	SampleCodeStrconvBitsize = []CodeSample{
+		{[]string{`
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	u64, err := strconv.ParseUint("2147483648", 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	value := int64(u64)
+	fmt.Println(value)
+}`}, 1, gosec.NewConfig()}, {[]string{`
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	u16, err := strconv.ParseUint("32768", 10, 16)
+	if err != nil {
+		panic(err)
+	}
+	if int16(u16) < 0 {
+		fmt.Println(bigValue)
+	}
+}`}, 1, gosec.NewConfig()}, {[]string{`
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	bigValue, err := strconv.ParseUint("2147483648", 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(bigValue)
+}`}, 0, gosec.NewConfig()}, {[]string{`
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	bigValue, err := strconv.Atoi("2147483648", 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(bigValue)
+	test()
+}
+
+func test() {
+	bigValue := 30
+	value := int32(bigValue)
+	fmt.Println(value)
+}`}, 0, gosec.NewConfig()}, {[]string{`
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	value := 10
+	if value == 10 {
+		value, _ := strconv.ParseUint("2147483648", 10, 64)
+		fmt.Println(value)
+	}
+	v := int32(value)
+	fmt.Println(v)
+}`}, 0, gosec.NewConfig()}}
 )


### PR DESCRIPTION
This change detects when a literal bitSize that's invalid
yet there is a cast from uint64 to int*: int16, int32, int64
and this change was one I found in the Cosmos-SDK in
https://github.com/cosmos/cosmos-sdk/issues/7627 and fixed
per https://github.com/cosmos/cosmos-sdk/pull/7628

For example:

idx, _ := strconv.ParseUint(str, 10, 64)
_ = int64(idx)

which causes an overflow.

Fixes #3