### PR TITLE
.github/workflows/ci: test on Go1.17,1.18,1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       matrix:
         go_version:
           - '1.17'
+          - '1.18'
+          - '1.19'
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on


### PR DESCRIPTION
Adds the ability for us to test on all of Go1.17,1.18,1.19