### PR TITLE
rules/errors: allow hash.Hash.Write to not return an error as its Go contract holds

### DIFF
--- a/rules/errors.go
+++ b/rules/errors.go
@@ -87,6 +87,7 @@ func NewNoErrorCheck(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	whitelist.AddAll("fmt", "Print", "Printf", "Println", "Fprint", "Fprintf", "Fprintln")
 	whitelist.AddAll("strings.Builder", "Write", "WriteByte", "WriteRune", "WriteString")
 	whitelist.Add("io.PipeWriter", "CloseWithError")
+	whitelist.Add("hash.Hash", "Write")
 
 	if configured, ok := conf["G104"]; ok {
 		if whitelisted, ok := configured.(map[string]interface{}); ok {


### PR DESCRIPTION
Allows hash.Hash.Write to not return an error as the Go contracts dictates at https://pkg.go.dev/hash#Hash.Write and thus it is useless to flag such.

Fixes #45