### PR TITLE
rules/sdk: exclude "testutil" from map ranging checks

### DIFF
--- a/rules/sdk/iterate_over_maps.go
+++ b/rules/sdk/iterate_over_maps.go
@@ -37,7 +37,24 @@ func (mr *mapRanging) ID() string {
 	return mr.MetaData.ID
 }
 
+// There are some packages that inherently need map ranging such as "testutil"
+// so return true if we detect such.
+func pkgExcusedFromMapRangingChecks(ctx *gosec.Context) bool {
+	switch pkg := ctx.Pkg.Name(); pkg {
+	case "gogoreflection", "simapp", "simulation", "testutil":
+		return true
+	default:
+		return false
+	}
+}
+
 func (mr *mapRanging) Match(node ast.Node, ctx *gosec.Context) (*gosec.Issue, error) {
+	if pkgExcusedFromMapRangingChecks(ctx) {
+		// Do nothing for such packages like "testutil".
+		// Please see https://github.com/cosmos/gosec/issues/50
+		return nil, nil
+	}
+
 	rangeStmt, ok := node.(*ast.RangeStmt)
 	if !ok {
 		return nil, nil


### PR DESCRIPTION
This change excludes "testutil" from map ranging checks given that such code is used for testing and no need to flag natural code to iterate over tests.

Fixes #50