### PR TITLE
rules/sdk: more accurately determine overflow for *int*(len(...)) by type & 32/64-bit architectures

### DIFF
--- a/rules/sdk/int_end_conversion_test.go
+++ b/rules/sdk/int_end_conversion_test.go
@@ -1,0 +1,65 @@
+package sdk
+
+import "testing"
+
+func TestCanOverflowChecks32Bits(t *testing.T) {
+	if !is32Bit {
+		t.Skip("Not running on a 64-bit machine!")
+	}
+
+	cases := []struct {
+		endKind      string
+		wantOverflow bool
+	}{
+		{"int8", true},
+		{"int16", true},
+		{"int32", false},
+		{"int64", false},
+		{"int", false},
+		{"uint8", true},
+		{"uint16", true},
+		{"uint32", false},
+		{"uint64", false},
+		{"uint", false},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.endKind, func(t *testing.T) {
+			if got := canLenOverflow32(tt.endKind); got != tt.wantOverflow {
+				t.Fatalf("Mismatch\n\tGot: %t\n\tWant:%t", got, tt.wantOverflow)
+			}
+		})
+	}
+}
+
+func TestCanOverflowChecks64Bits(t *testing.T) {
+	if is32Bit {
+		t.Skip("Not running on a 32-bit machine!")
+	}
+
+	cases := []struct {
+		endKind      string
+		wantOverflow bool
+	}{
+		{"int8", true},
+		{"int16", true},
+		{"int32", true},
+		{"int", false},
+		{"int64", false},
+		{"uint8", true},
+		{"uint16", true},
+		{"uint32", true},
+		{"uint64", false},
+		{"uint", false},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.endKind, func(t *testing.T) {
+			if got := canLenOverflow64(tt.endKind); got != tt.wantOverflow {
+				t.Fatalf("Mismatch\n\tGot: %t\n\tWant:%t", got, tt.wantOverflow)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Depending on the machine that the rule is being run on, determine if the result of an integer cast to len(value) will overflow e.g.

* int8, uint8, int16, uint16 (len(value)) will always overflow on 32/64-bits
* uint32(len(value)) shall overflow on 64-bit machines but not on 32-bit
* int64(len(value)) cannot overflow on 64-bit machines nor on 32-bit
* int(len(value)) cannot overflow on either 64-bit or 32-bit machines
* uint(len(value)) cannot overflow on either 64-bit or 32-bit machines

Fixes #54