### PR TITLE
rules/sdk: exempt "core", "runtime" from map iteration checks

### DIFF
--- a/rules/sdk/iterate_over_maps.go
+++ b/rules/sdk/iterate_over_maps.go
@@ -41,7 +41,7 @@ func (mr *mapRanging) ID() string {
 // so return true if we detect such.
 func pkgExcusedFromMapRangingChecks(ctx *gosec.Context) bool {
 	switch pkg := ctx.Pkg.Name(); pkg {
-	case "gogoreflection", "simapp", "simulation", "testutil":
+	case "core", "gogoreflection", "proto", "runtime", "simapp", "simulation", "testutil":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Noticed in a bunch of cosmos-sdk patterns that "runtime" is a package that heavily uses maps for proto and file descriptor manipulation so let's excuse it from map range checks; same thing for "core"